### PR TITLE
Use commit sha instead of head_ref in `remote.sh` test

### DIFF
--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -27,6 +27,6 @@ jobs:
         run: sudo apt-get install -y git stow
 
       - name: Run curl
-        run: curl -L https://raw.githubusercontent.com/${{ github.repository }}/${BRANCH}/remote.sh | bash
+        run: curl -L https://raw.githubusercontent.com/${{ github.repository }}/${SHA}/remote.sh | bash
         env:
-          BRANCH: ${{ github.head_ref || 'master' }}
+          SHA: ${{ github.sha }}


### PR DESCRIPTION
- SSIA